### PR TITLE
Add `isInstanceOf` code generation

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1007,9 +1007,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           tree.ensureConforms(defn.ObjectType).select(defn.Object_eq).appliedTo(singleton(tp))
         else
           singleton(tp).equal(tree)
-      case refine.EventuallyQualifiedType(qualified, predicate: Tree) => // TODO: Remove
-        //TODO: add isInstance(qualified)
-        predicate.appliedTo(tree)
       case _ =>
         tree.select(defn.Any_isInstanceOf).appliedToType(tp)
     }

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1007,6 +1007,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           tree.ensureConforms(defn.ObjectType).select(defn.Object_eq).appliedTo(singleton(tp))
         else
           singleton(tp).equal(tree)
+      case refine.EventuallyQualifiedType(qualified, predicate: Tree) => // TODO: Remove
+        //TODO: add isInstance(qualified)
+        predicate.appliedTo(tree)
       case _ =>
         tree.select(defn.Any_isInstanceOf).appliedToType(tp)
     }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1454,6 +1454,10 @@ object Types {
     /** Like `dealiasKeepAnnots`, but keeps only refining annotations */
     final def dealiasKeepRefiningAnnots(using Context): Type = dealias1(keepIfRefining, keepOpaques = false)
 
+    /** Like `dealiasKeepAnnots`, but keeps only qualifying annotations */
+    final def dealiasKeepQualifyingAnnots(using Context): Type = dealias1(keepIfQualifying, keepOpaques = false)
+
+
     /** Follow non-opaque aliases and dereferences LazyRefs, annotated types and instantiated
      *  TypeVars until type is no longer alias type, annotated type, LazyRef,
      *  or instantiated type variable.
@@ -6618,6 +6622,7 @@ object Types {
   private val keepAlways: AnnotatedType => Context ?=> Boolean = _ => true
   private val keepNever: AnnotatedType => Context ?=> Boolean = _ => false
   private val keepIfRefining: AnnotatedType => Context ?=> Boolean = _.isRefining
+  private val keepIfQualifying: AnnotatedType => Context ?=> Boolean = {case refine.EventuallyQualifiedType(_) => true case _ => false}
 
   val isBounds: Type => Boolean = _.isInstanceOf[TypeBounds]
 }

--- a/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
@@ -105,6 +105,12 @@ object BetaReduce:
       case _ =>
         tree
 
+  def apply(ddef: DefDef, argss: List[List[Tree]])(using Context): Tree =
+    val bindings = new ListBuffer[DefTree]()
+    val expansion1 = BetaReduce.reduceApplication(ddef, argss, bindings)
+    val bindings1 = bindings.result()
+    seq(bindings1, expansion1)
+
   /** Beta-reduces a call to `ddef` with arguments `args` and registers new bindings */
   def reduceApplication(ddef: DefDef, argss: List[List[Tree]], bindings: ListBuffer[DefTree])(using Context): Tree =
     val (targs, args) = argss.flatten.partition(_.isType)

--- a/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
@@ -59,14 +59,10 @@ class InlinePatterns extends MiniPhase:
       case Block(TypeDef(_, template: Template) :: Nil, Apply(Select(New(_),_), Nil)) if template.constr.rhs.isEmpty =>
         template.body match
           case List(ddef @ DefDef(`name`, _, _, _)) =>
-            val bindings = new ListBuffer[DefTree]()
-            val expansion1 = BetaReduce.reduceApplication(ddef, argss, bindings)
-            val bindings1 = bindings.result()
-            seq(bindings1, expansion1)
+            BetaReduce(ddef, argss)
           case _ => tree
       case _ => tree
 
 object InlinePatterns:
   val name: String = "inlinePatterns"
   val description: String = "remove placeholders of inlined patterns"
-

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -775,16 +775,10 @@ object PatternMatcher {
               addOuterTest(tree, tycon)
             case _ =>
               tree
-          // Should only keep qualified type annots ! (dealiasKeepAnnots does not do that)
-          expectedTp.dealiasKeepAnnots match
+
+          expectedTp.dealias match
             case expectedTp: SingletonType =>
               scrutinee.isInstance(expectedTp)  // will be translated to an equality test
-            case refine.EventuallyQualifiedType(qualified, predicate) =>
-              val qualTypeTest = scrutinee.select(defn.Any_typeTest).appliedToType(qualified) // Not correct, should be recursive
-              val predTest = predicate.appliedTo(scrutinee)
-
-              qualTypeTest.and(predTest)
-
             case _ =>
               addOuterTest(typeTest(scrutinee, expectedTp), expectedTp)
     end emitCondition

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -317,7 +317,7 @@ object TypeTestsCasts {
          *  The transform happens before erasure of `testType`, thus cannot be merged
          *  with `transformIsInstanceOf`, which depends on erased type of `testType`.
          */
-        def transformTypeTest(expr: Tree, testType: Type, flagUnrelated: Boolean): Tree = testType.dealiasKeepAnnots match { //TODO: Change this to one that only keeps qualified types
+        def transformTypeTest(expr: Tree, testType: Type, flagUnrelated: Boolean): Tree = testType.dealiasKeepQualifyingAnnots match {
           case tref: TermRef if tref.symbol == defn.EmptyTupleModule =>
             ref(defn.RuntimeTuples_isInstanceOfEmptyTuple).appliedTo(expr)
           case _: SingletonType =>

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -336,7 +336,7 @@ object TypeTestsCasts {
             evalOnce(expr) { e =>
               // e.isInstanceOf[baseType] && qualifier(e.asInstanceOf[baseType])
               transformTypeTest(e, baseType, flagUnrelated)
-                .and(BetaReduce(qualifier, List(e.asInstance(baseType))))
+                .and(BetaReduce(qualifier, List(List(e.asInstance(baseType)))))
             }
           case defn.MultiArrayOf(elem, ndims) if isGenericArrayElement(elem, isScala2 = false) =>
             def isArrayTest(arg: Tree) =

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -215,6 +215,7 @@ class CompilationTests {
       compileFilesInDir("tests/run-custom-args/erased", defaultOptions.and("-language:experimental.erasedDefinitions")),
       compileFilesInDir("tests/run-custom-args/fatal-warnings", defaultOptions.and("-Xfatal-warnings")),
       compileFilesInDir("tests/run-custom-args/captures", allowDeepSubtypes.and("-language:experimental.captureChecking")),
+      compileFilesInDir("tests/run-custom-args/qualified-types", defaultOptions.and("-language:experimental.qualifiedTypes")),
       compileFilesInDir("tests/run-deep-subtype", allowDeepSubtypes),
       compileFilesInDir("tests/run", defaultOptions.and("-Ysafe-init")),
       // Run tests for legacy lazy vals.

--- a/tests/neg-custom-args/qualified-types/qualified-types.scala
+++ b/tests/neg-custom-args/qualified-types/qualified-types.scala
@@ -29,10 +29,15 @@ object postfixLambda:
 
   type MultipleWildcards = Int with _ > _ // error: Qualified type's qualifier contains 2 wildcards ('_'), when the maximum is 1
 
-  def foo(x: Int with y => x > 0) = ???// error: Cyclic reference involving val x
+  def foo(x: Int with y => x > 0) = ??? // error: Cyclic reference involving val x
 
   type Nesting = Int with { val y: Int with _ > 0 = ??? ; _ > y } // error
 
   // TODO: fix the following ?
   def f: Int => Boolean = x => true
   type Call = Int with f // error
+
+  class A:
+    private val b: Boolean = true
+
+    type myInt = Int with b // error: non-private refers to private

--- a/tests/run-custom-args/qualified-types/patmat.check
+++ b/tests/run-custom-args/qualified-types/patmat.check
@@ -1,0 +1,6 @@
+It Pos
+It not Pos
+It not Pos
+It not Pos
+It not Pos
+It not Pos

--- a/tests/run-custom-args/qualified-types/patmat.check
+++ b/tests/run-custom-args/qualified-types/patmat.check
@@ -4,3 +4,9 @@ It not Pos
 It not Pos
 It not Pos
 It not Pos
+It Polite
+It Impolite
+It Impolite
+It Impolite
+It Impolite
+It Impolite

--- a/tests/run-custom-args/qualified-types/patmat.check
+++ b/tests/run-custom-args/qualified-types/patmat.check
@@ -1,12 +1,12 @@
-It Pos
-It not Pos
-It not Pos
-It not Pos
-It not Pos
-It not Pos
-It Polite
-It Impolite
-It Impolite
-It Impolite
-It Impolite
-It Impolite
+hello: It not Pos, and It Impolite
+c: It not Pos, and It Impolite
+List(): It not Pos, and It Impolite
+72: It Pos, and It Impolite
+4: It Pos, and It Impolite
+0: It not Pos, and It Impolite
+-1: It not Pos, and It Impolite
+Give me the butter, please: It not Pos, and It Polite
+give me the butter, please: It not Pos, and It Impolite
+Give me the butter: It not Pos, and It Impolite
+give me the butter: It not Pos, and It Impolite
+: It not Pos, and It Impolite

--- a/tests/run-custom-args/qualified-types/patmat.scala
+++ b/tests/run-custom-args/qualified-types/patmat.scala
@@ -22,6 +22,12 @@ inline val isPoliteFalse = "It Impolite"
 @main
 def Test =
 
+  val l0 = List[Int](-1, 0, 1, 4)
+  val l1 = for case (x: Pos) <- l0 yield x
+  val l2 = l0.collect{ case x: (Pos | 0) => math.sqrt(x) }
+  assert( l1 == List(1, 4))
+  assert( l2 == List(0, 1, 2))
+
   val examples = List( // val, isPosBool, isPoliteBool
     ("hello",                       false, false),
     ('c',                           false, false),

--- a/tests/run-custom-args/qualified-types/patmat.scala
+++ b/tests/run-custom-args/qualified-types/patmat.scala
@@ -1,23 +1,26 @@
 import language.experimental.setNotation
 
-val b = true
+
+type Pos = {x: Int with x > 0}
+
+inline val isPosTrue = "It Pos"
+inline val isPosFalse = "It not Pos"
+
+def isPos(x: Any) = x match
+  case x: Pos => isPosTrue
+  case _ => isPosFalse
+
 
 type NonEmptyString = {s: String with !s.isEmpty}
 
 type PoliteString = {s: NonEmptyString with s.head.isUpper && s.takeRight(6) == "please"}
 
-
-type Pos = {x: Int with x > 0}
-val scrut: Any = 4
-
-inline val isPosTrue = "It Pos"
-inline val isPosFalse = "It not Pos"
-
 inline val isPoliteTrue = "It Polite"
 inline val isPoliteFalse = "It Impolite"
 
-
-
+def isPolite(x: Any) = x match
+  case x: PoliteString => isPoliteTrue
+  case _ => isPoliteFalse
 
 @main
 def Test =
@@ -55,12 +58,3 @@ def Test =
     assert( isPolite(v) == expectedPoliteStr )
 
     println(s"$v: ${isPos(v)}, and ${isPolite(v)}")
-
-
-def isPos(x: Any) = x match
-  case x: Pos => isPosTrue
-  case _ => isPosFalse
-
-def isPolite(x: Any) = x match
-  case x: PoliteString => isPoliteTrue
-  case _ => isPoliteFalse

--- a/tests/run-custom-args/qualified-types/patmat.scala
+++ b/tests/run-custom-args/qualified-types/patmat.scala
@@ -1,6 +1,12 @@
 import language.experimental.setNotation
 
 val b = true
+
+type NonEmptyString = {s: String with !s.isEmpty}
+
+type PoliteString = {s: NonEmptyString with s.head.isUpper && s.takeRight(6) == "please"}
+
+
 type Pos = {x: Int with x > 0}
 val scrut: Any = 4
 
@@ -14,7 +20,22 @@ def Test =
   println(isPos('c'))
   println(isPos(List()))
 
+  println(isPolite("Give me the butter, please"))
+  println(isPolite("give me the butter, please"))
+  println(isPolite("Give me the butter"))
+  println(isPolite("Give me the butter"))
+  println(isPolite("")) // if checks were not done in correct order, it would result in "".head which would fail at runtime
+  println(isPolite(72))
+
 def isPos(x: Any) = x match
   case x: Pos => "It Pos"
   case _ => "It not Pos"
 
+def isPos2(x: Int) = x match
+  case x: Pos => "It Pos"
+  case _ => "It not Pos"
+
+
+def isPolite(x: Any) = x match
+  case x: PoliteString => "It Polite"
+  case _ => "It Impolite"

--- a/tests/run-custom-args/qualified-types/patmat.scala
+++ b/tests/run-custom-args/qualified-types/patmat.scala
@@ -10,32 +10,51 @@ type PoliteString = {s: NonEmptyString with s.head.isUpper && s.takeRight(6) == 
 type Pos = {x: Int with x > 0}
 val scrut: Any = 4
 
+inline val isPosTrue = "It Pos"
+inline val isPosFalse = "It not Pos"
+
+inline val isPoliteTrue = "It Polite"
+inline val isPoliteFalse = "It Impolite"
+
+
+
+
 @main
 def Test =
-  println(isPos(4))
-  println(isPos(0))
-  println(isPos(-1))
 
-  println(isPos("hello"))
-  println(isPos('c'))
-  println(isPos(List()))
+  val examples = List( // val, isPosBool, isPoliteBool
+    ("hello",                       false, false),
+    ('c',                           false, false),
+    (List(),                        false, false),
 
-  println(isPolite("Give me the butter, please"))
-  println(isPolite("give me the butter, please"))
-  println(isPolite("Give me the butter"))
-  println(isPolite("Give me the butter"))
-  println(isPolite("")) // if checks were not done in correct order, it would result in "".head which would fail at runtime
-  println(isPolite(72))
+    (72,                            true,  false),
+    (4,                             true,  false),
+    (0,                             false, false),
+    (-1,                            false, false),
+
+    ("Give me the butter, please",  false, true ),
+    ("give me the butter, please",  false, false),
+    ("Give me the butter",          false, false),
+    ("give me the butter",          false, false),
+    ("",                            false, false), // if checks were not done in correct order, it would result in "".head which would fail at runtime
+  )
+
+  examples.foreach: (v, expectedPosBool, expectedPoliteBool) =>
+    val expectedPosStr = if expectedPosBool then isPosTrue else isPosFalse
+    assert( v.isInstanceOf[Pos] == expectedPosBool )
+    assert( isPos(v) == expectedPosStr )
+
+    val expectedPoliteStr = if expectedPoliteBool then isPoliteTrue else isPoliteFalse
+    assert( v.isInstanceOf[PoliteString] == expectedPoliteBool )
+    assert( isPolite(v) == expectedPoliteStr )
+
+    println(s"$v: ${isPos(v)}, and ${isPolite(v)}")
+
 
 def isPos(x: Any) = x match
-  case x: Pos => "It Pos"
-  case _ => "It not Pos"
-
-def isPos2(x: Int) = x match
-  case x: Pos => "It Pos"
-  case _ => "It not Pos"
-
+  case x: Pos => isPosTrue
+  case _ => isPosFalse
 
 def isPolite(x: Any) = x match
-  case x: PoliteString => "It Polite"
-  case _ => "It Impolite"
+  case x: PoliteString => isPoliteTrue
+  case _ => isPoliteFalse

--- a/tests/run-custom-args/qualified-types/patmat.scala
+++ b/tests/run-custom-args/qualified-types/patmat.scala
@@ -1,0 +1,20 @@
+import language.experimental.setNotation
+
+val b = true
+type Pos = {x: Int with x > 0}
+val scrut: Any = 4
+
+@main
+def Test =
+  println(isPos(4))
+  println(isPos(0))
+  println(isPos(-1))
+
+  println(isPos("hello"))
+  println(isPos('c'))
+  println(isPos(List()))
+
+def isPos(x: Any) = x match
+  case x: Pos => "It Pos"
+  case _ => "It not Pos"
+


### PR DESCRIPTION
This adds handling of qualified types in `isInstanceOf`, a bit naive about polymorphic methods, but there is already a warning at declaration site for these

Future work is to distinguish between two kinds of qualified types:
* Those that can be distinguished at compiletime
* Those who can't

And warn the user when the latter are used in `isInstanceOf`, similarly to what is done for `isInstanceOf[A => B]`